### PR TITLE
Fix module compatibility for Slovenian language

### DIFF
--- a/payu/payu.php
+++ b/payu/payu.php
@@ -708,7 +708,6 @@ class PayU extends PaymentModule
      */
     public function hookBackOfficeHeader()
     {
-        $output = '<link type="text/css" rel="stylesheet" href="' . _MODULE_DIR_ . $this->name . '/css/payu.css" /><script type="text/javascript" src="https://static.payu.com/res/v2/prestashop-plugin.js"></script>';
 
         return $output;
     }

--- a/payu/payu.php
+++ b/payu/payu.php
@@ -708,7 +708,7 @@ class PayU extends PaymentModule
      */
     public function hookBackOfficeHeader()
     {
-        $output = '<link type="text/css" rel="stylesheet" href="' . _MODULE_DIR_ . $this->name . '/css/payu.css" />';
+        $output = '<link type="text/css" rel="stylesheet" href="' . _MODULE_DIR_ . $this->name . '/css/payu.css" /><script type="text/javascript" src="https://static.payu.com/res/v2/prestashop-plugin.js"></script>';
 
         return $output;
     }
@@ -737,12 +737,14 @@ class PayU extends PaymentModule
                     'order_reference' => $params['template_vars']['{order_name}']
                 ];
                 $url = $this->context->link->getPageLink('guest-tracking', null, null, $urlParams);
+                $url = str_replace(' ', '%20', $url);
 
             } else {
                 $urlParams = [
                     'id_order' => $id_order
                 ];
                 $url = $this->context->link->getPageLink('order-detail', null, null, $urlParams);
+                $url = str_replace(' ', '%20', $url);
             }
 
             $params['extra_template_vars']['{payment}'] = $params['template_vars']['{payment}'] . ', <a href="' . $url . '#repayment">' . $this->l('Repay by PayU') . '</a>';
@@ -1630,6 +1632,8 @@ class PayU extends PaymentModule
         ];
         $continueUrl = $this->context->link->getPageLink('order-confirmation', null, null, $params);
 
+        $continueUrl = str_replace(' ', '%20', $continueUrl);
+
         $ocreq = [
             'merchantPosId' => OpenPayU_Configuration::getMerchantPosId(),
             'description' => $this->l('Order:') . ' ' . $this->order->id . ' - ' . $this->order->reference . ', ' . $this->l('Store:') . ' ' . Configuration::get('PS_SHOP_NAME'),
@@ -2067,7 +2071,7 @@ class PayU extends PaymentModule
     {
         $iso = Language::getIsoById($this->context->language->id);
 
-        return $iso === 'gb' ? 'en' : $iso;
+        return in_array($iso, ['gb', 'si']) ? 'en' : $iso;
     }
 
     /**


### PR DESCRIPTION
The module did not support the Slovenian version of the site. I equated it to the English version. 
The continueUrl variable returned a URL with a literal space instead of %20, so I fixed it. 
I also applied the same fix to the url variable.  
Tested on PrestaShop 1.7.8.11.

The code below is just one possible solution. 
Please review the issue and apply the necessary corrections to the original code.